### PR TITLE
Reaction to comments of ppoile

### DIFF
--- a/test-one-stone-at-a-time.sh
+++ b/test-one-stone-at-a-time.sh
@@ -26,8 +26,9 @@ run_blue_stone () {
     echo "valve1=on"
     sleep .3
     echo "valve1=off"
+    sleep .1
     echo "lightbarrier3=on"
-    sleep .45
+    sleep 3
     echo "lightbarrier3=off"
 }
 
@@ -45,8 +46,9 @@ run_red_stone () {
     echo "valve2=on"
     sleep .3
     echo "valve2=off"
+    sleep .1
     echo "lightbarrier4=on"
-    sleep .45
+    sleep 3
     echo "lightbarrier4=off"
 }
 
@@ -64,8 +66,9 @@ run_white_stone () {
     echo "valve3=on"
     sleep .3
     echo "valve3=off"
+    sleep .1
     echo "lightbarrier5=on"
-    sleep .45
+    sleep 3
     echo "lightbarrier5=off"
 }
 

--- a/test-stones-close-together.sh
+++ b/test-stones-close-together.sh
@@ -26,8 +26,9 @@ run_blue_stone () {
     echo "valve1=on"
     sleep .3
     echo "valve1=off"
+    sleep .1
     echo "lightbarrier3=on"
-    sleep .45
+    sleep 3
     echo "lightbarrier3=off"
 }
 
@@ -45,8 +46,9 @@ run_red_stone () {
     echo "valve2=on"
     sleep .3
     echo "valve2=off"
+    sleep .1
     echo "lightbarrier4=on"
-    sleep .45
+    sleep 3
     echo "lightbarrier4=off"
 }
 
@@ -64,8 +66,9 @@ run_white_stone () {
     echo "valve3=on"
     sleep .3
     echo "valve3=off"
+    sleep .1
     echo "lightbarrier5=on"
-    sleep .45
+    sleep 3
     echo "lightbarrier5=off"
 }
 

--- a/test-stones-even-closer-together.sh
+++ b/test-stones-even-closer-together.sh
@@ -13,8 +13,9 @@ stop_hardware () {
 }
 run_blue_stone () { 
     echo "lightbarrier1=on"
-    sleep .1
+    sleep .45
     echo "lightbarrier1=off"
+    sleep 1.33
     echo "color=blue"
     sleep 1.56
     echo "lightbarrier2=on"
@@ -24,15 +25,17 @@ run_blue_stone () {
     echo "valve1=on"
     sleep .3
     echo "valve1=off"
+    sleep .1
     echo "lightbarrier3=on"
-    sleep .45
+    sleep 3
     echo "lightbarrier3=off"
 }
 
 run_red_stone () { 
     echo "lightbarrier1=on"
-    sleep .1
+    sleep .45
     echo "lightbarrier1=off"
+    sleep 1.33
     echo "color=red"
     sleep 1.56
     echo "lightbarrier2=on"
@@ -42,15 +45,17 @@ run_red_stone () {
     echo "valve2=on"
     sleep .3
     echo "valve2=off"
+    sleep .1
     echo "lightbarrier4=on"
-    sleep .45
+    sleep 3
     echo "lightbarrier4=off"
 }
 
 run_white_stone () {
     echo "lightbarrier1=on"
-    sleep .1
+    sleep .45
     echo "lightbarrier1=off"
+    sleep 1.33
     echo "color=white"
     sleep 1.56
     echo "lightbarrier2=on"
@@ -60,8 +65,9 @@ run_white_stone () {
     echo "valve3=on"
     sleep .3
     echo "valve3=off"
+    sleep .1
     echo "lightbarrier5=on"
-    sleep .45
+    sleep 3
     echo "lightbarrier5=off"
 }
 

--- a/test-stones-even-closer-with-undetected.sh
+++ b/test-stones-even-closer-with-undetected.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# conveyor-speed=58mm/s
+
+start_hardware () {
+    echo "conveyor=running"
+    echo "compressor=start"
+}
+
+stop_hardware () {
+    echo "conveyor=stopped"
+    echo "compressor=stop"
+}
+run_blue_stone () { 
+    echo "lightbarrier1=on"
+    sleep .1
+    echo "lightbarrier1=off"
+    echo "color=blue"
+    sleep 1.56
+    echo "lightbarrier2=on"
+    sleep .45
+    echo "lightbarrier2=off"
+    sleep .24
+    echo "valve1=on"
+    sleep .3
+    echo "valve1=off"
+    sleep .1
+    echo "lightbarrier3=on"
+    sleep 3
+    echo "lightbarrier3=off"
+}
+
+run_red_stone () { 
+    echo "lightbarrier1=on"
+    sleep .1
+    echo "lightbarrier1=off"
+    echo "color=red"
+    sleep 1.56
+    echo "lightbarrier2=on"
+    sleep .45
+    echo "lightbarrier2=off"
+    sleep 1.42
+    echo "valve2=on"
+    sleep .3
+    echo "valve2=off"
+    sleep .1
+    echo "lightbarrier4=on"
+    sleep 3
+    echo "lightbarrier4=off"
+}
+
+run_white_stone () {
+    echo "lightbarrier1=on"
+    sleep .1
+    echo "lightbarrier1=off"
+    echo "color=white"
+    sleep 1.56
+    echo "lightbarrier2=on"
+    sleep .45
+    echo "lightbarrier2=off"
+    sleep 2.19
+    echo "valve3=on"
+    sleep .3
+    echo "valve3=off"
+    sleep .1
+    echo "lightbarrier5=on"
+    sleep 3
+    echo "lightbarrier5=off"
+}
+
+run_undetected_stone () {
+    echo "lightbarrier1=on"
+    sleep .1
+    echo "lightbarrier1=off"
+    echo "color=transparent"
+    sleep 1.56
+    echo "lightbarrier2=on"
+    sleep .45
+    echo "lightbarrier2=off"
+}
+
+echo "Setting up the hardware in 2 secs" >&2
+sleep 2
+echo "Set up the hardware now..." >&2
+start_hardware &
+
+echo "Waiting 1 secs before we begin with the first stone..." >&2
+sleep 1
+echo "...and here we go..." >&2
+
+run_blue_stone &
+sleep 1.7
+run_red_stone &
+sleep 1.7
+run_white_stone &
+sleep 1.7
+run_undetected_stone &
+sleep 6
+
+echo "Finished" >&2
+echo "Stop the hardware" >&2
+stop_hardware &


### PR DESCRIPTION
- The comments of ppoile on sleep times in test-stones-even-closer-together.sh have been considered
- Adaptation of sleep times of tray lightbarrier to react on newest gui functionality (deletion of stones, after tray lightbarrier goes off)
- Split different versions of test-stones-even-closer-together.sh in two files, one with the "old" original values and a new one test-stones-even-closer-with-undetected.sh, which is based on the "newer" version of goerks/bbvch/farbsort-websocket@563bda8, but also adapted to stone removal from tray